### PR TITLE
cache computationally intensive values for duration

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -56,6 +56,9 @@
 
     <script>
       function addMarkerForCentroid(cent) {
+	if (!cent)
+	  return;
+
 	var color = cent.color;
 	var cur = cent.centroid;
 	var properties = cur.properties;
@@ -72,17 +75,22 @@
 	    'marker-description': 'centroid',
 	  }),
 	})
-	.bindPopup('<div>Magnitude: ' + magnitude + '</div><br /><div>Depth: ' + depth + '</div><br /><div class="trigger">' + detail +
-	  '</div><br /><div>View details about it <a target="_blank" href="' + properties.url + '">here</a>')
+	.bindPopup('<div>Magnitude: ' + magnitude + '</div><div>Depth: ' + depth + '</div><div class="trigger">' + detail + '</div>' +
+	  '<div>View details about it <a target="_blank" href="' + properties.url + '">here</a>')
 	.addTo(map);
 
-	// Then make a marker for each point under that centroid.
-	cent.points.forEach(function(point) {
-	  addMarker(point, color);
-	});
+	if (cent.points && cent.points.length > 0) {
+	  // Then make a marker for each point under that centroid.
+	  cent.points.forEach(function(point) {
+	    addMarker(point, color);
+	  });
+	}
       }
       
       function addMarker(point, color) {
+	if (!point)
+	  return;
+
 	var coords = point.geometry.coordinates;
 	var depth = coords.depth;
 	var detail = point.properties.place;
@@ -96,8 +104,8 @@
 	    'marker-color': color,
 	  }),
 	})
-	.bindPopup('<div>Magnitude: ' + magnitude + '</div><br /><div>Depth: ' + depth + '</div><br /><div class="trigger">' + detail +
-	  '</div><br /><div>View details about it <a target="_blank" href="' + url + '">here</a>')
+	.bindPopup('<div>Magnitude: ' + magnitude + '</div><div>Depth: ' + depth + '</div><div class="trigger">' + detail + '</div>' +
+	  '<div>View details about it <a target="_blank" href="' + url + '">here</a>')
 	.addTo(map);
       }
     </script>


### PR DESCRIPTION
KMeans clustering every single time is an expensive operation
compared to every other operation.
Cache these values for (canonical duration) / 2.
The division by 2 is an arbitrary decision to ensure that
values that slide within a time window will be refreshed e.g
1 hour --> 30 minutes so that the values will refresh after
30 minutes. In the future, the better fix would be to
always fetch values from USGS but only check the cache if
they those values haven't changed from the clustering.